### PR TITLE
gn: Fix build with newer gn versions.

### DIFF
--- a/src/cpp/BUILD.gn
+++ b/src/cpp/BUILD.gn
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 static_library("procyon-cpp") {
-  sources = [
+  public = [
     "include/pn/arg",
     "include/pn/array",
     "include/pn/data",
@@ -23,6 +23,9 @@ static_library("procyon-cpp") {
     "include/pn/output",
     "include/pn/string",
     "include/pn/value",
+  ]
+
+  sources = [
     "src/array.cpp",
     "src/common.hpp",
     "src/data.cpp",


### PR DESCRIPTION
This fixes the build with the system version of gn I have installed. Since upstream gn does not provide release tarballs I used one of gentoo's.

https://dev.gentoo.org/~floppym/dist/gn-0.1616.tar.xz
https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-util/gn

I tested this building antares with:
```
sed -i 's|build/lib/bin/gn|gn|' build/lib/scripts/cfg.py
```
And this fixes this build issue.
```
generating build.ninja...ERROR at //ext/procyon/src/cpp/BUILD.gn:24:5: Only source, header, and object files belong in the sources of a static_library. //ext/procyon/src/cpp/include/pn/value is not one of the valid types.
    "include/pn/value",
    ^-----------------
See //ext/procyon/BUILD.gn:23:5: which caused the file to be included.
    "src/cpp:procyon-cpp",
    ^--------------------
     failed
```
I also tested the internal gn version and it built fine.

Reference: https://gn.googlesource.com/gn/+/master/docs/reference.md#var_friend

Note I only tested this against `antares-0.9.0`.