### PR TITLE
Visual Studio compilation/crash fixes

### DIFF
--- a/src/c/include/pn/procyon.h
+++ b/src/c/include/pn/procyon.h
@@ -16,6 +16,7 @@
 #define PROCYON_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -131,7 +132,7 @@ extern const struct pn_value pn_mapempty;    // {}
 // ?: bool
 // i: int I: unsigned int
 // b: int8, B: uint8, h: int16, H: uint16, l: int32, L: uint32, q: int64, Q: uint64
-// p: intptr_t, P: uintptr_t (or a pointer), z: size_t, Z: ssize_t
+// p: intptr_t, P: uintptr_t (or a pointer), z: size_t, Z: ptrdiff_t
 // f: float, d: double
 // s: const char* (NUL-terminated), S: const char* and size_t
 // c: char (becomes a 1-character string), C: uint32_t (becomes a 1-rune string)

--- a/src/c/src/dump.c
+++ b/src/c/src/dump.c
@@ -109,7 +109,7 @@ static bool dump_bool(pn_bool_t b, pn_output_t* out) {
 
 static bool dump_int(pn_int_t i, pn_output_t* out) {
     char    buf[32];
-    ssize_t len;
+    ptrdiff_t len;
     return ((len = sprintf(buf, "%" PRId64, i)) > 0) && pn_raw_write(out, buf, len);
 }
 
@@ -576,7 +576,7 @@ bool pn_dump(pn_output_t* out, int flags, int format, ...) {
         case 'p': x.type = PN_INT, x.i = va_arg(vl, intptr_t); break;
         case 'P': x.type = PN_INT, x.i = va_arg(vl, uintptr_t); break;
         case 'z': x.type = PN_INT, x.i = va_arg(vl, size_t); break;
-        case 'Z': x.type = PN_INT, x.i = va_arg(vl, ssize_t); break;
+        case 'Z': x.type = PN_INT, x.i = va_arg(vl, ptrdiff_t); break;
 
         case 'f': x.type = PN_FLOAT, x.f = va_arg(vl, double); break;
         case 'd': x.type = PN_FLOAT, x.f = va_arg(vl, double); break;

--- a/src/c/src/format.c
+++ b/src/c/src/format.c
@@ -45,7 +45,7 @@ struct format_arg {
         intptr_t          p;
         uintptr_t         P;
         size_t            z;
-        ssize_t           Z;
+        ptrdiff_t         Z;
         double            d;  // f
         const char*       s;
         const pn_array_t* a;
@@ -78,7 +78,7 @@ static void set_arg(char format, struct format_arg* dst, va_list* vl) {
         case 'p': dst->p = va_arg(*vl, intptr_t); break;
         case 'P': dst->P = va_arg(*vl, uintptr_t); break;
         case 'z': dst->z = va_arg(*vl, size_t); break;
-        case 'Z': dst->Z = va_arg(*vl, ssize_t); break;
+        case 'Z': dst->Z = va_arg(*vl, ptrdiff_t); break;
 
         case 'f': format = 'f';
         case 'd': dst->d = va_arg(*vl, double); break;
@@ -110,7 +110,7 @@ static void set_arg(char format, struct format_arg* dst, va_list* vl) {
 
 static bool print_u(pn_output_t* out, uint64_t u) {
     char    buf[32];
-    ssize_t len;
+    ptrdiff_t len;
     return ((len = sprintf(buf, "%" PRIu64, u)) > 0) && pn_write(out, "S", buf, (size_t)len);
 }
 

--- a/src/c/src/io.h
+++ b/src/c/src/io.h
@@ -26,11 +26,11 @@ struct pn_input_view {
     size_t      size;
 };
 
-int     pn_getc(pn_input_t* in);
-int     pn_putc(int ch, pn_output_t* out);
-bool    pn_raw_read(pn_input_t* in, void* data, size_t size);
-bool    pn_raw_write(pn_output_t* out, const void* data, size_t size);
-ssize_t pn_getline(pn_input_t* in, char** data, size_t* size);
+int        pn_getc(pn_input_t* in);
+int        pn_putc(int ch, pn_output_t* out);
+bool       pn_raw_read(pn_input_t* in, void* data, size_t size);
+bool       pn_raw_write(pn_output_t* out, const void* data, size_t size);
+ptrdiff_t  pn_getline(pn_input_t* in, char** data, size_t* size);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/c/src/lex.c
+++ b/src/c/src/lex.c
@@ -82,7 +82,7 @@ static bool next_line(pn_lexer_t* lex, pn_error_t* error) {
             ++lex->lineno;
         }
         lex->prev_width  = lex->line.end - lex->line.begin;
-        ssize_t size     = pn_getline(lex->in, &lex->buffer.data, &lex->buffer.size);
+        ptrdiff_t size   = pn_getline(lex->in, &lex->buffer.data, &lex->buffer.size);
         lex->token.begin = lex->token.end = lex->line.begin = lex->line.end = lex->buffer.data;
         if (size <= 0) {
             if (pn_input_error(lex->in)) {

--- a/src/c/src/lex.h
+++ b/src/c/src/lex.h
@@ -76,7 +76,7 @@ typedef struct {
         char*           end;
     } token;
     size_t  lineno;
-    ssize_t indent;
+    ptrdiff_t indent;
     size_t  prev_width;
     bool    eq;
 
@@ -93,7 +93,7 @@ typedef struct {
     struct {
         size_t  count;
         size_t  size;
-        ssize_t values[];
+        ptrdiff_t values[];
     } * levels;
 } pn_lexer_t;
 

--- a/src/c/src/procyon.c
+++ b/src/c/src/procyon.c
@@ -26,7 +26,7 @@
 #include "./utf8.h"
 #include "./vector.h"
 
-const pn_value_t pn_null    = {};
+const pn_value_t pn_null    = {.type = PN_NULL};
 const pn_value_t pn_true    = {.type = PN_BOOL, .b = true};
 const pn_value_t pn_false   = {.type = PN_BOOL, .b = false};
 const pn_value_t pn_inf     = {.type = PN_FLOAT, .f = INFINITY};
@@ -105,7 +105,7 @@ bool pn_vset(pn_value_t* dst, char format, va_list* vl) {
         case 'p': dst->type = PN_INT; dst->i = va_arg(*vl, intptr_t); return true;
         case 'P': dst->type = PN_INT; dst->i = va_arg(*vl, uintptr_t); return true;
         case 'z': dst->type = PN_INT; dst->i = va_arg(*vl, size_t); return true;
-        case 'Z': dst->type = PN_INT; dst->i = va_arg(*vl, ssize_t); return true;
+        case 'Z': dst->type = PN_INT; dst->i = va_arg(*vl, ptrdiff_t); return true;
 
         case 'f': dst->type = PN_FLOAT; dst->f = va_arg(*vl, double); return true;
         case 'd': dst->type = PN_FLOAT; dst->f = va_arg(*vl, double); return true;
@@ -399,7 +399,7 @@ void pn_arrayins(pn_array_t** a, size_t index, int format, ...) {
     pn_value_t* src = &(*a)->values[index];
     void*       dst = src + 1;
     void*       end = &(*a)->values[(*a)->count];
-    memmove(dst, src, end - dst);
+    memmove(dst, src, (char*)end - (char*)dst);
 
     va_list vl;
     va_start(vl, format);
@@ -412,7 +412,7 @@ void pn_arraydel(pn_array_t** a, size_t index) {
     void*       src = dst + 1;
     void*       end = &(*a)->values[(*a)->count--];
     pn_clear(dst);
-    memmove(dst, src, end - src);
+    memmove(dst, src, (char*)end - (char*)src);
 }
 
 void pn_arrayresize(pn_array_t** a, size_t size) {

--- a/src/cpp/include/pn/arg
+++ b/src/cpp/include/pn/arg
@@ -108,7 +108,7 @@ struct arg<uintptr_t, zero_if_not_in<uintptr_t, uint32_t, uint64_t>::value> : po
 template <>
 struct arg<size_t, zero_if_not_in<size_t, uintptr_t, uint32_t, uint64_t>::value> : pod_arg<size_t, 'z'> {};
 template <>
-struct arg<ssize_t, zero_if_not_in<ssize_t, intptr_t, int32_t, int64_t>::value> : pod_arg<ssize_t, 'Z'> {};
+struct arg<ptrdiff_t, zero_if_not_in<ptrdiff_t, intptr_t, int32_t, int64_t>::value> : pod_arg<ptrdiff_t, 'Z'> {};
 template <>
 struct arg<void*> : pod_arg<void*, 'P'> {};
 

--- a/src/cpp/include/pn/input
+++ b/src/cpp/include/pn/input
@@ -101,8 +101,9 @@ void read(pn_input_t* in, const char* format, const tuple& args) {
 
 template <typename... args>
 input& input::read(args... arg) {
+    const char str[] = {internal::read_arg<typename std::decay<args>::type>::code..., '\0'};
     internal::read(
-            c_obj(), (char[]){internal::read_arg<typename std::decay<args>::type>::code..., '\0'},
+            c_obj(), str,
             std::tuple_cat(
                     internal::read_arg<typename std::decay<args>::type>::read_args(arg)...));
     return *this;
@@ -110,8 +111,9 @@ input& input::read(args... arg) {
 
 template <typename... args>
 input_view& input_view::read(args... arg) {
+    const char str[] = {internal::read_arg<typename std::decay<args>::type>::code..., '\0'};
     internal::read(
-            c_obj(), (char[]){internal::read_arg<typename std::decay<args>::type>::code..., '\0'},
+            c_obj(), str,
             std::tuple_cat(
                     internal::read_arg<typename std::decay<args>::type>::read_args(arg)...));
     return *this;

--- a/src/cpp/include/pn/output
+++ b/src/cpp/include/pn/output
@@ -163,16 +163,19 @@ string dump(const arg& x, int flags) {
 
 template <typename... args>
 output& output::write(const args&... arg) {
+    const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::write(
-            c_obj(), (char[]){internal::arg<typename std::decay<args>::type>::code..., '\0'},
+            c_obj(), str,
             std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
     return *this;
 }
 
+
 template <typename... args>
 output_view& output_view::write(const args&... arg) {
+    const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::write(
-            c_obj(), (char[]){internal::arg<typename std::decay<args>::type>::code..., '\0'},
+            c_obj(), str,
             std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
     return *this;
 }
@@ -195,16 +198,18 @@ output_view& output_view::dump(const arg& x, int flags) {
 
 template <typename... args>
 output& output::format(const char* fmt, const args&... arg) {
+    const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::format(
-            c_obj(), fmt, (char[]){internal::arg<typename std::decay<args>::type>::code..., '\0'},
+            c_obj(), fmt, str,
             std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
     return *this;
 }
 
 template <typename... args>
 output_view& output_view::format(const char* fmt, const args&... arg) {
+    const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::format(
-            c_obj(), fmt, (char[]){internal::arg<typename std::decay<args>::type>::code..., '\0'},
+            c_obj(), fmt, str,
             std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
     return *this;
 }

--- a/src/cpp/include/pn/string
+++ b/src/cpp/include/pn/string
@@ -21,6 +21,7 @@
 #include <pn/fwd>
 #include <pn/value>
 #include <string>
+#include <array>
 
 namespace pn {
 
@@ -73,7 +74,7 @@ class rune {
     uint32_t              value() const { return pn_rune(data(), 4, 0); }
     constexpr const char* data() const { return _data; }
     constexpr size_type   size() const {
-        return (char[]){1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 2, 2, 3, 4}[uint8_t(*data()) >> 4];
+        return static_cast<size_type>("\1\1\1\1\1\1\1\1\0\0\0\0\2\2\3\4"[((*data()) >> 4) & 0xf]);
     }
 
     string copy() const;

--- a/src/cpp/include/pn/value
+++ b/src/cpp/include/pn/value
@@ -19,6 +19,8 @@
 #include <pn/procyon.h>
 #include <pn/fwd>
 
+#include <string>
+
 namespace pn {
 
 class value {
@@ -58,8 +60,8 @@ class value {
     void swap(value& x) { std::swap(*c_obj(), *x.c_obj()); }
     void swap(value&& x) { std::swap(*c_obj(), *x.c_obj()); }
 
-    c_obj_type*             c_obj() { return &_c_obj; }
-    c_obj_const_type const* c_obj() const { return &_c_obj; }
+    c_obj_type*                       c_obj() { return &_c_obj; }
+    constexpr c_obj_const_type const* c_obj() const { return &_c_obj; }
 
     value copy() const {
         pn_value_t x;
@@ -111,7 +113,7 @@ class value_ref {
     constexpr value_ref(value& x) : value_ref{x.c_obj()} {}
     const value_ref& operator=(value x) const { return std::swap(*c_obj(), *x.c_obj()), *this; }
 
-    c_obj_type* c_obj() const { return _c_obj; }
+    constexpr c_obj_type* c_obj() const { return _c_obj; }
 
     value copy() const {
         pn_value_t x;

--- a/src/cpp/test/dump.test.cpp
+++ b/src/cpp/test/dump.test.cpp
@@ -430,7 +430,7 @@ TEST_F(DumpTest, AllCTypes) {
     EXPECT_THAT(dump<intptr_t>('p', -128), IsString("-128\n"));
     EXPECT_THAT(dump<uintptr_t>('P', 128), IsString("128\n"));
     EXPECT_THAT(dump<size_t>('z', -256), IsString("-256\n"));
-    EXPECT_THAT(dump<ssize_t>('Z', 256), IsString("256\n"));
+    EXPECT_THAT(dump<ptrdiff_t>('Z', 256), IsString("256\n"));
 
     EXPECT_THAT(dump<float>('f', 1.5), IsString("1.5\n"));
     EXPECT_THAT(dump<double>('d', 2.5), IsString("2.5\n"));

--- a/src/cpp/test/format.test.cpp
+++ b/src/cpp/test/format.test.cpp
@@ -99,7 +99,7 @@ TEST_F(FormatTest, Scalar) {
     EXPECT_THAT(pn::format<intptr_t>("format: {0}", 1), IsString("format: 1"));
     EXPECT_THAT(pn::format<uintptr_t>("format: {0}", 1), IsString("format: 1"));
     EXPECT_THAT(pn::format<size_t>("format: {0}", 1), IsString("format: 1"));
-    EXPECT_THAT(pn::format<ssize_t>("format: {0}", 1), IsString("format: 1"));
+    EXPECT_THAT(pn::format<ptrdiff_t>("format: {0}", 1), IsString("format: 1"));
 
     EXPECT_THAT(pn::format<float>("format: {0}", 1.0), IsString("format: 1.0"));
     EXPECT_THAT(pn::format<double>("format: {0}", 1.0), IsString("format: 1.0"));

--- a/src/cpp/test/value.test.cpp
+++ b/src/cpp/test/value.test.cpp
@@ -132,7 +132,7 @@ TEST_F(ValueTest, Set) {
     EXPECT_THAT(set<intptr_t>('p', 11), IsInt(11));
     EXPECT_THAT(set<uintptr_t>('P', 12), IsInt(12));
     EXPECT_THAT(set<size_t>('z', 13), IsInt(13));
-    EXPECT_THAT(set<ssize_t>('Z', 14), IsInt(14));
+    EXPECT_THAT(set<ptrdiff_t>('Z', 14), IsInt(14));
 
     EXPECT_THAT(set<float>('f', M_PI), IsFloat(static_cast<float>(M_PI)));
     EXPECT_THAT(set<double>('d', M_PI), IsFloat(static_cast<double>(M_PI)));


### PR DESCRIPTION
- Use ptrdiff_t instead of ssize_t.
- Use SSE CSR instead of x87 control word in dtoa (and use intrinsics instead of assembly)
- Init only-default C structures as {0} instead of {}
- Don't use va_arg multiple times in parameter lists, this depends on undefined behavior that is causing VS to pass garbage.  Parameters (and their subexpressions) are not guaranteed to be evaluated in any specific order, and va_arg has side-effects, so using it multiple times in the same parameter list is bad.
- Don't do pointer arithmetic on void*
- Don't declare char literal arrays as expressions
- Fix missing <array> include
- Fix constexpr functions calling non-constexpr functions