### PR TITLE
Workaround for Visual Studio internal compiler error.

### DIFF
--- a/src/cpp/include/pn/arg
+++ b/src/cpp/include/pn/arg
@@ -44,6 +44,8 @@ struct read_arg<T*> : arg<T> {};
 template <>
 struct arg<pad> {
     static constexpr char     code = '#';
+    typedef std::tuple<size_t> write_args_type;
+    typedef std::tuple<size_t> read_args_type;
     static std::tuple<size_t> write_args(pad p) { return std::make_tuple(p.size); }
     static std::tuple<size_t> read_args(pad p) { return std::make_tuple(p.size); }
 };
@@ -53,12 +55,16 @@ struct read_arg<pad> : arg<pad> {};
 template <>
 struct arg<std::nullptr_t> {
     static constexpr char code = 'n';
+    typedef std::tuple<> write_args_type;
+    typedef std::tuple<> read_args_type;
     static std::tuple<>   write_args(std::nullptr_t) { return std::make_tuple(); }
 };
 
 template <typename T, char C>
 struct pod_arg {
     static constexpr char code = C;
+    typedef std::tuple<T> write_args_type;
+    typedef std::tuple<T> read_args_type;
     static std::tuple<T> write_args(T t) { return std::make_tuple(t); }
     static std::tuple<T*> read_args(T* t) { return std::make_tuple(t); }
 };
@@ -115,6 +121,8 @@ struct arg<void*> : pod_arg<void*, 'P'> {};
 template <>
 struct arg<const char*> {
     static constexpr char          code = 's';
+    typedef std::tuple<const char*> write_args_type;
+    typedef std::tuple<const char*> read_args_type;
     static std::tuple<const char*> write_args(const char* s) { return std::make_tuple(s); }
 };
 template <>
@@ -123,6 +131,7 @@ struct arg<char*> : arg<const char*> {};
 template <>
 struct arg<data_view> {
     static constexpr char code = '$';
+    typedef std::tuple<const uint8_t*, size_t> write_args_type;
     static std::tuple<const uint8_t*, size_t> write_args(data_view d) {
         return std::make_tuple(d.data(), d.size());
     }
@@ -131,6 +140,8 @@ struct arg<data_view> {
 template <>
 struct arg<data> {
     static constexpr char code = '$';
+    typedef std::tuple<const uint8_t*, size_t> write_args_type;
+    typedef std::tuple<uint8_t*, size_t> read_args_type;
     static std::tuple<const uint8_t*, size_t> write_args(const data& d) {
         return std::make_tuple(d.data(), d.size());
     }
@@ -142,6 +153,8 @@ struct arg<data> {
 template <>
 struct arg<data_ref> {
     static constexpr char code = '$';
+    typedef std::tuple<const uint8_t*, size_t> write_args_type;
+    typedef std::tuple<uint8_t*, size_t> read_args_type;
     static std::tuple<const uint8_t*, size_t> write_args(const data_ref& d) {
         return std::make_tuple(d.data(), d.size());
     }
@@ -153,6 +166,7 @@ struct arg<data_ref> {
 template <>
 struct arg<string_view> {
     static constexpr char code = 'S';
+    typedef std::tuple<const char*, size_t> write_args_type;
     static std::tuple<const char*, size_t> write_args(string_view s) {
         return std::make_tuple(s.data(), s.size());
     }
@@ -169,6 +183,7 @@ struct arg<rune> : arg<string_view> {};
 template <>
 struct arg<array_cref> {
     static constexpr char                code = 'a';
+    typedef std::tuple<const pn_array_t*> write_args_type;
     static std::tuple<const pn_array_t*> write_args(array_cref a) {
         return std::make_tuple(*a.c_obj());
     }
@@ -181,6 +196,7 @@ struct arg<array_ref> : arg<array_cref> {};
 template <>
 struct arg<map_cref> {
     static constexpr char              code = 'm';
+    typedef std::tuple<const pn_map_t*> write_args_type;
     static std::tuple<const pn_map_t*> write_args(map_cref m) {
         return std::make_tuple(*m.c_obj());
     }
@@ -193,6 +209,7 @@ struct arg<map_ref> : arg<map_cref> {};
 template <>
 struct arg<value_cref> {
     static constexpr char                code = 'x';
+    typedef std::tuple<const pn_value_t*> write_args_type;
     static std::tuple<const pn_value_t*> write_args(value_cref x) {
         return std::make_tuple(x.c_obj());
     }

--- a/src/cpp/include/pn/output
+++ b/src/cpp/include/pn/output
@@ -23,9 +23,110 @@
 #include <pn/map>
 #include <pn/string>
 #include <pn/value>
+#include <pn/tuple_type_cat>
 #include <type_traits>
 
 namespace pn {
+
+namespace internal {
+
+
+template<typename... args>
+struct write_and_concat_args
+{
+    static typename tuple_type_cat<typename internal::arg<typename std::decay<args>::type>::write_args_type...>::type process(const args&... arg);
+};
+
+template<>
+struct write_and_concat_args<>
+{
+    static typename std::tuple<> process();
+};
+
+#ifdef _MSC_VER
+// Workaround for VS internal compiler error in pack expander
+
+template<typename dest_tuple, int dest_index, typename src_tuple, int src_index>
+void tuple_copy_element(dest_tuple& dest, const src_tuple& src)
+{
+    std::get<dest_index>(dest) = std::get<src_index>(src);
+}
+
+template<typename dest_tuple, int dest_index, typename src_tuple, int src_index, int remaining>
+struct tuple_copy_range_part
+{
+    static void copy(dest_tuple& dest, const src_tuple& src);
+};
+
+template<typename dest_tuple, int dest_index, typename src_tuple, int src_index>
+struct tuple_copy_range_part<dest_tuple, dest_index, src_tuple, src_index, 0>
+{
+    static void copy(dest_tuple& dest, const src_tuple& src) {}
+};
+
+
+template<typename dest_tuple, int dest_index, typename src_tuple, int src_index, int remaining>
+void tuple_copy_range_part<dest_tuple, dest_index, src_tuple, src_index, remaining>::copy(dest_tuple& dest, const src_tuple& src)
+{
+    tuple_copy_element<dest_tuple, dest_index, src_tuple, src_index>(dest, src);
+	tuple_copy_range_part<dest_tuple, dest_index + 1, src_tuple, src_index + 1, remaining - 1>::copy(dest, src);
+}
+
+template<typename dest_tuple, int dest_index, typename src_tuple>
+void insert_tuple(dest_tuple& dest, const src_tuple& src)
+{
+    tuple_copy_range_part<dest_tuple, dest_index, src_tuple, 0, std::tuple_size<src_tuple>::value>::copy(dest, src);
+}
+
+template<typename dest_tuple, int dest_index, typename arg_type>
+void write_one_arg(dest_tuple& dest, const arg_type& arg)
+{
+    typedef typename internal::arg<typename std::decay<arg_type>::type>::write_args_type arg_write_type_t;
+    insert_tuple<dest_tuple, dest_index, arg_write_type_t>(dest, internal::arg<typename std::decay<arg_type>::type>::write_args(arg));
+}
+
+template<typename dest_tuple, size_t dest_index, typename... args>
+void write_args(dest_tuple& dest, const args&... arg);
+
+template<typename dest_tuple, size_t dest_index, typename args>
+void write_args(dest_tuple& dest, const args& arg)
+{
+    write_one_arg<dest_tuple, dest_index, args>(dest, arg);
+}
+
+template<typename dest_tuple, size_t dest_index, typename arg0_type, typename... args>
+void write_args(dest_tuple& dest, const arg0_type& arg0, const args&... arg)
+{
+    typedef typename internal::arg<typename std::decay<arg0_type>::type>::write_args_type arg0_write_type_t;
+    write_one_arg<dest_tuple, dest_index, arg0_type>(dest, arg0);
+    write_args<dest_tuple, dest_index + std::tuple_size<arg0_write_type_t>::value, args...>(dest, arg...);
+}
+
+template<typename... args>
+typename tuple_type_cat<typename internal::arg<typename std::decay<args>::type>::write_args_type...>::type write_and_concat_args<args...>::process(const args&... arg)
+{
+    typedef typename tuple_type_cat<typename internal::arg<typename std::decay<args>::type>::write_args_type...>::type dest_tuple_t;
+	dest_tuple_t result;
+	write_args<dest_tuple_t, 0, args...>(result, arg...);
+	return result;
+}
+
+#else
+
+template<typename... args>
+typename tuple_type_cat<typename internal::arg<typename std::decay<args>::type>::write_args_type...>::type write_and_concat_args<args...>::process(const args&... arg)
+{
+    return std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...);
+}
+
+#endif
+
+inline std::tuple<> write_and_concat_args<>::process()
+{
+    return std::tuple<>();
+}
+
+}  // namespace internal
 
 enum {
     dump_default = PN_DUMP_DEFAULT,
@@ -166,7 +267,7 @@ output& output::write(const args&... arg) {
     const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::write(
             c_obj(), str,
-            std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
+            internal::write_and_concat_args<args...>::process(arg...));
     return *this;
 }
 
@@ -176,7 +277,7 @@ output_view& output_view::write(const args&... arg) {
     const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::write(
             c_obj(), str,
-            std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
+            internal::write_and_concat_args<args...>::process(arg...));
     return *this;
 }
 
@@ -184,7 +285,7 @@ template <typename arg>
 output& output::dump(const arg& x, int flags) {
     internal::dump(
             c_obj(), flags, internal::arg<typename std::decay<arg>::type>::code,
-            internal::arg<typename std::decay<arg>::type>::write_args(x));
+            internal::write_and_concat_args<arg>::process(x));
     return *this;
 }
 
@@ -192,7 +293,7 @@ template <typename arg>
 output_view& output_view::dump(const arg& x, int flags) {
     internal::dump(
             c_obj(), flags, internal::arg<typename std::decay<arg>::type>::code,
-            internal::arg<typename std::decay<arg>::type>::write_args(x));
+            internal::write_and_concat_args<arg>::process(x));
     return *this;
 }
 
@@ -201,7 +302,7 @@ output& output::format(const char* fmt, const args&... arg) {
     const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::format(
             c_obj(), fmt, str,
-            std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
+            internal::write_and_concat_args<args...>::process(arg...));
     return *this;
 }
 
@@ -210,7 +311,7 @@ output_view& output_view::format(const char* fmt, const args&... arg) {
     const char str[] = {internal::arg<typename std::decay<args>::type>::code..., '\0'};
     internal::format(
             c_obj(), fmt, str,
-            std::tuple_cat(internal::arg<typename std::decay<args>::type>::write_args(arg)...));
+            internal::write_and_concat_args<args...>::process(arg...));
     return *this;
 }
 

--- a/src/cpp/include/pn/tuple_type_cat
+++ b/src/cpp/include/pn/tuple_type_cat
@@ -1,0 +1,47 @@
+
+// -*- mode: C++ -*-
+// Copyright 2022 The Procyon Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PN_TUPLE_TYPE_CAT_
+#define PN_TUPLE_TYPE_CAT_
+
+namespace pn {
+namespace internal {
+
+template <typename... ty>
+struct tuple_type_cat;
+
+template <typename ty>
+struct tuple_type_cat<ty>
+{
+    typedef ty type;
+};
+
+template <typename... ty0, typename... ty1>
+struct tuple_type_cat<std::tuple<ty0...>, std::tuple<ty1...>>
+{
+    typedef std::tuple<ty0..., ty1...> type;
+};
+
+template <typename... ty0, typename... ty1, typename... ty_more>
+struct tuple_type_cat<std::tuple<ty0...>, std::tuple<ty1...>, ty_more...>
+    : public tuple_type_cat<std::tuple<ty0...>, typename tuple_type_cat<std::tuple<ty1...>, ty_more...>::type>
+{
+};
+
+}  // namespace internal
+}  // namespace pn
+
+#endif


### PR DESCRIPTION
Workaround for `internal::arg<typename std::decay<args>::type>::write_args(arg)...` causing an internal compiler error in Visual Studio.
https://developercommunity.visualstudio.com/t/Internal-compiler-error-when-using-param/1654868